### PR TITLE
Fix body decoding

### DIFF
--- a/src/requests.ts
+++ b/src/requests.ts
@@ -3,6 +3,8 @@ import { parseChatData, getOptionsFromLivePage } from "./parser"
 import { FetchOptions } from "./types/yt-response"
 import { ChatItem, YoutubeId } from "./types/data"
 
+axios.defaults.headers.common["Accept-Encoding"] = "utf-8"
+
 export async function fetchChat(options: FetchOptions): Promise<[ChatItem[], string]> {
   const url = `https://www.youtube.com/youtubei/v1/live_chat/get_live_chat?key=${options.apiKey}`
   const res = await axios.post(url, {


### PR DESCRIPTION
Hello i came across your package today but it wouldn't work no matter what livestream i used, looking a bit onto the code i found out axios was the responsible for this, the response's bodies weren't being decoded correctly and therefore the checks to make sure there was a livestream running weren't working, adding this one line fixed the issue, please test it on your end to make sure it works :^)

This code:

``` js
const { LiveChat } = require("youtube-chat");

const liveChat = new LiveChat({channelId: "UCV306eHqgo0LvBf3Mh36AHg"});

// Emit at start of observation chat.
// liveId: string
liveChat.on("start", (liveId) => {
    console.log("start");
});

// Emit at end of observation chat.
// reason: string?
liveChat.on("end", (reason) => {
    console.log("end");
});

// Emit at receive chat.
// chat: ChatItem
liveChat.on("chat", (chatItem) => {
    console.log(chatItem);
})

// Emit when an error occurs
// err: Error or any
liveChat.on("error", (err) => {
    console.log(err);
});

(async () => {
    // Start fetch loop
    const ok = await liveChat.start();
    if (!ok) {
    console.log("Failed to start, check emitted error");
    }
})();
```

Gave me this error:
``` bash
$ node main.js

Error: Live Stream was not found
    at getOptionsFromLivePage (.../node_modules/youtube-chat/dist/parser.js:11:15)
    at .../node_modules/youtube-chat/dist/requests.js:41:52
    at Generator.next (<anonymous>)
    at fulfilled (.../node_modules/youtube-chat/dist/requests.js:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
Failed to start, check emitted error
```

*getOptionsFromLivePage* was receiving [this](https://pastebin.com/2ur8qZy9) as *data*:
